### PR TITLE
fix: example network slicing method doesn't work 

### DIFF
--- a/slicing.py
+++ b/slicing.py
@@ -15,8 +15,9 @@ def slice_network(G, T, copy=True):
     Remove all edges with weight<T from G or its copy.
     """
     F = G.copy() if copy else G
-    F.remove_edges_from((n1, n2) for n1, n2, w in F.edges(data="weight")
-                        if w < T)
+    edgelist = list(F.edges(data=True))
+    F.remove_edges_from((n1, n2) for n1, n2, w in edgelist
+        if w['weight'] < T)
     return F
 
 # Draw different degrees of slicing for a random graph

--- a/slicing.py
+++ b/slicing.py
@@ -15,9 +15,9 @@ def slice_network(G, T, copy=True):
     Remove all edges with weight<T from G or its copy.
     """
     F = G.copy() if copy else G
-    edgelist = list(F.edges(data=True))
+    edgelist = list(F.edges(data="weight"))
     F.remove_edges_from((n1, n2) for n1, n2, w in edgelist
-        if w['weight'] < T)
+        if w < T)
     return F
 
 # Draw different degrees of slicing for a random graph


### PR DESCRIPTION
For the current example in the network slicing section of the book, a runtime error is currently thrown on execution. This is because the edge dictionary is changed during iteration.
![image](https://user-images.githubusercontent.com/46619169/133142009-a956d7a1-cba3-4cb5-9276-41dc5a67dece.png)

I changed this method so it iterates over a copy of the edgelist, fixing this problem. The example should now run in current python/networkx versions

